### PR TITLE
feat: refactoring - transaction daytrade logic

### DIFF
--- a/gerenciador-investimentos/src/main/kotlin/com/vitorbasso/gerenciadorinvestimentos/service/concrete/TransactionService.kt
+++ b/gerenciador-investimentos/src/main/kotlin/com/vitorbasso/gerenciadorinvestimentos/service/concrete/TransactionService.kt
@@ -17,6 +17,10 @@ internal class TransactionService(
 
     fun save(transaction: Transaction) = this.transactionRepository.save(transaction)
 
+    fun saveAndFlush(transaction: Transaction) = this.transactionRepository.saveAndFlush(transaction)
+
+    fun saveAll(transactions: List<Transaction>) = this.transactionRepository.saveAll(transactions)
+
     fun findTransactionsOnSameDate(transaction: Transaction)
         = this.transactionRepository.findByAssetAndTransactionDateOrderByTransactionDate(
         transaction.asset,

--- a/gerenciador-investimentos/src/main/kotlin/com/vitorbasso/gerenciadorinvestimentos/service/facade/TransactionServiceFacadeImpl.kt
+++ b/gerenciador-investimentos/src/main/kotlin/com/vitorbasso/gerenciadorinvestimentos/service/facade/TransactionServiceFacadeImpl.kt
@@ -8,6 +8,7 @@ import com.vitorbasso.gerenciadorinvestimentos.service.IAssetService
 import com.vitorbasso.gerenciadorinvestimentos.service.ITransactionService
 import com.vitorbasso.gerenciadorinvestimentos.service.concrete.StockService
 import com.vitorbasso.gerenciadorinvestimentos.service.concrete.TransactionService
+import com.vitorbasso.gerenciadorinvestimentos.util.DaytradeUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.DayOfWeek
@@ -32,8 +33,29 @@ internal class TransactionServiceFacadeImpl(
     ).let {
         transactionRequest.getTransaction(it)
     }.let {
-        this.transactionService.save(processTransaction(it))
+        processTransaction(it)
     }
+
+    private fun processTransaction(transaction: Transaction): Transaction {
+        val transactionProcessed = processDaytrade(this.transactionService.saveAndFlush(transaction))
+        this.walletService.updateBalance(
+            transactionProcessed,
+            this.monthlyWalletService
+        )
+        return transactionProcessed
+    }
+
+    private fun processDaytrade(transaction: Transaction)
+    = this.transactionService.findTransactionsOnSameDate(transaction).let {
+        this.transactionService.saveAll(DaytradeUtil.reprocessTransactionsForDaytrade(it)).find {
+            processedTransaction ->
+            processedTransaction.id == transaction.id
+        } ?: transaction
+    }
+
+    private fun checkDate(dateToCheck: LocalDate) = dateToCheck.takeIf {
+        !it.isAfter(LocalDate.now()) && (it.dayOfWeek != DayOfWeek.SATURDAY || it.dayOfWeek != DayOfWeek.SUNDAY)
+    } ?: throw CustomWrongDateException()
 
     private fun TransactionRequest.getTransaction(asset: Asset) = Transaction(
         type = this.type,
@@ -42,101 +64,5 @@ internal class TransactionServiceFacadeImpl(
         asset = asset,
         transactionDate = checkDate(this.date)
     )
-
-    private fun checkDate(dateToCheck: LocalDate) = dateToCheck.takeIf {
-        !it.isAfter(LocalDate.now()) && (it.dayOfWeek != DayOfWeek.SATURDAY || it.dayOfWeek != DayOfWeek.SUNDAY)
-    } ?: throw CustomWrongDateException()
-
-    private fun processTransaction(transaction: Transaction): Transaction {
-        val processedTransactionForDaytrade = processDaytrade(transaction)
-        this.walletService.updateBalance(
-            processedTransactionForDaytrade,
-            this.monthlyWalletService
-        )
-        return processedTransactionForDaytrade
-    }
-
-    private fun processDaytrade(transaction: Transaction): Transaction {
-
-        val sameDayTransactions = this.transactionService.findTransactionsOnSameDate(transaction)
-
-        var sameTypeTransactionAssetQuantity = -1 * sameDayTransactions.filter {
-            it.type == transaction.type && it.daytradeQuantity != it.quantity
-        }.fold(0) { total, sameTypeTransaction ->
-            total + sameTypeTransaction.quantity
-        }
-
-        val otherTypeTransactionList = sameDayTransactions.filter {
-            it.type != transaction.type && it.daytradeQuantity != it.quantity
-        }
-
-        var quantityStillAvailableForDaytrade = 0
-
-        for (otherTypeTransaction in otherTypeTransactionList) {
-            sameTypeTransactionAssetQuantity += otherTypeTransaction.quantity - otherTypeTransaction.daytradeQuantity
-            if (sameTypeTransactionAssetQuantity > 0) {
-                quantityStillAvailableForDaytrade = updatePastTransactionsForDaytrade(
-                    otherTypeTransactions = otherTypeTransactionList.subList(
-                        otherTypeTransactionList.indexOf(otherTypeTransaction),
-                        otherTypeTransactionList.size
-                    ),
-                    lastQuantityStillAvailableForDaytrade = sameTypeTransactionAssetQuantity,
-                    transactionQuantity = transaction.quantity
-                )
-                break
-            }
-        }
-
-        return if (sameTypeTransactionAssetQuantity > 0)
-            transaction.copy(
-                daytrade = true,
-                daytradeQuantity = transaction.quantity - quantityStillAvailableForDaytrade
-            )
-        else transaction
-    }
-
-    private fun updatePastTransactionsForDaytrade(
-        otherTypeTransactions: List<Transaction>,
-        lastQuantityStillAvailableForDaytrade: Int,
-        transactionQuantity: Int
-    ): Int {
-        var quantityLeftAvailableForDaytrading = transactionQuantity
-
-        otherTypeTransactions.forEachIndexed { index, transaction ->
-            if (quantityLeftAvailableForDaytrading > 0) {
-                quantityLeftAvailableForDaytrading = updatePastTransaction(
-                    transaction = transaction,
-                    quantityLeft = quantityLeftAvailableForDaytrading,
-                    quantityAvailableToUse =
-                    if (index > 0 || lastQuantityStillAvailableForDaytrade <= 0) transaction.quantity
-                    else lastQuantityStillAvailableForDaytrade
-                )
-            }
-        }
-
-        return quantityLeftAvailableForDaytrading
-    }
-
-    private fun updatePastTransaction(
-        transaction: Transaction,
-        quantityLeft: Int,
-        quantityAvailableToUse: Int
-    ) = if (quantityLeft > quantityAvailableToUse) {
-        this.transactionService.save(
-            transaction.copy(
-                daytrade = true,
-                daytradeQuantity = transaction.quantity
-            )
-        )
-        quantityLeft - quantityAvailableToUse
-    } else {
-        this.transactionService.save(
-            transaction.copy(
-                daytrade = true,
-                daytradeQuantity = transaction.quantity - (quantityAvailableToUse - quantityLeft)
-            )
-        )
-        0
-    }
 
 }

--- a/gerenciador-investimentos/src/main/kotlin/com/vitorbasso/gerenciadorinvestimentos/util/DaytradeUtil.kt
+++ b/gerenciador-investimentos/src/main/kotlin/com/vitorbasso/gerenciadorinvestimentos/util/DaytradeUtil.kt
@@ -1,0 +1,68 @@
+package com.vitorbasso.gerenciadorinvestimentos.util
+
+import com.vitorbasso.gerenciadorinvestimentos.domain.concrete.Transaction
+import com.vitorbasso.gerenciadorinvestimentos.enum.TransactionType
+import org.springframework.stereotype.Component
+
+@Component
+object DaytradeUtil {
+
+    fun reprocessTransactionsForDaytrade(sameDayTransactions: List<Transaction>): List<Transaction>{
+
+        val changedTransactions = mutableListOf<Transaction>()
+
+        val (buyTransactions, sellTransactions) = getBuyAndSellLists(sameDayTransactions)
+
+        if(buyTransactions.isEmpty() || sellTransactions.isEmpty()) return sameDayTransactions
+
+        for(buyTransaction in buyTransactions) {
+            if(!attemptToFillAvailableDaytradeQuantity(buyTransaction, sellTransactions, changedTransactions))
+                break
+        }
+
+        if(sellTransactions.isNotEmpty() && sellTransactions.first().daytrade)
+            changedTransactions.add(sellTransactions.first())
+
+        return changedTransactions
+    }
+
+    private fun attemptToFillAvailableDaytradeQuantity(
+        typeOneTransaction: Transaction,
+        typeTwoTransactions: MutableList<Transaction>,
+        modifiedTransactions: MutableList<Transaction>
+    ): Boolean {
+        var quantityAvailable = typeOneTransaction.quantity - typeOneTransaction.daytradeQuantity
+        while (quantityAvailable > 0 && typeTwoTransactions.isNotEmpty()) {
+            val typeTwoTransaction = typeTwoTransactions.removeFirst()
+            val typeTwoAvailableQuantity = typeTwoTransaction.quantity - typeTwoTransaction.daytradeQuantity
+            if(typeTwoAvailableQuantity <= quantityAvailable) {
+                modifiedTransactions.add(typeTwoTransaction.copy(
+                    daytrade = true,
+                    daytradeQuantity = typeTwoTransaction.quantity
+                ))
+                quantityAvailable -= typeTwoAvailableQuantity
+            } else {
+                typeTwoTransactions.add(0, typeTwoTransaction.copy(
+                    daytrade = true,
+                    daytradeQuantity = typeTwoTransaction.daytradeQuantity + quantityAvailable
+                ))
+                quantityAvailable = 0
+            }
+        }
+        modifiedTransactions.add(typeOneTransaction.copy(
+            daytrade = true,
+            daytradeQuantity = typeOneTransaction.quantity - quantityAvailable
+        ))
+        return typeTwoTransactions.isNotEmpty()
+    }
+
+    private fun getBuyAndSellLists(sameDayTransactions: List<Transaction>) = (sameDayTransactions.map {
+        it.copy(
+            daytrade = false,
+            daytradeQuantity = 0
+        )
+    }.partition {
+        it.type == TransactionType.BUY
+    }).let { Pair(it.first.toMutableList(), it.second.toMutableList()) }
+
+}


### PR DESCRIPTION
Refactoring how Daytrade calculation works. Now it recalculates every transaction on the same day of the new one (this will allow for correctly removing transactions without messing up state more easily). This calculation has also been moved from TransactionService to an Util class
It also makes it much easier to maintain and understand the code since this is one of the most challenging aspects of the project
closes #45 